### PR TITLE
Implements user-defined markers

### DIFF
--- a/Configuration.cpp
+++ b/Configuration.cpp
@@ -83,6 +83,7 @@ bool Configuration::readConfigFile(const char *path) {
         trace->traceEvent(TRACE_ERROR, "Markers values must be positive in %s", path);
         return(false);
     }
+    trace->traceEvent(TRACE_INFO, "Markers are set to: unknown %d, pass %d, drop %d", marker_unknown, marker_pass, marker_drop);
   }
 
   if(root["default_policy"].empty()) {

--- a/Configuration.cpp
+++ b/Configuration.cpp
@@ -58,21 +58,30 @@ bool Configuration::readConfigFile(const char *path) {
   } else{
     if(root["markers"]["unknown"].empty()){
       trace->traceEvent(TRACE_ERROR, "Missing %s from %s", "unknown", path);
-        return(false);
+      return(false);
     }else{
       marker_unknown.setValue(root["markers"]["unknown"].asUInt());
     }
     if(root["markers"]["pass"].empty()){
       trace->traceEvent(TRACE_ERROR, "Missing %s from %s", "pass", path);
-        return(false);
+      return(false);
     }else{
       marker_pass.setValue(root["markers"]["pass"].asUInt());
     }
     if(root["markers"]["drop"].empty()){
       trace->traceEvent(TRACE_ERROR, "Missing %s from %s", "drop", path);
-        return(false);
+      return(false);
     }else{
       marker_drop.setValue(root["markers"]["drop"].asUInt());
+    }
+    if (marker_drop==marker_pass || marker_pass==marker_unknown || 
+        marker_drop==marker_unknown){
+        trace->traceEvent(TRACE_ERROR, "Markers values must be distinct in %s", path);
+        return(false);
+    }
+    if(marker_drop<0 || marker_pass<0 || marker_unknown<0){
+        trace->traceEvent(TRACE_ERROR, "Markers values must be positive in %s", path);
+        return(false);
     }
   }
 

--- a/Configuration.cpp
+++ b/Configuration.cpp
@@ -52,13 +52,37 @@ bool Configuration::readConfigFile(const char *path) {
   } else
     nfq_queue_id = root["queue_id"].asUInt();
 
+  if(root["markers"].empty()) {
+    trace->traceEvent(TRACE_ERROR, "Missing %s from %s", "markers", path);
+    return(false);
+  } else{
+    if(root["markers"]["unknown"].empty()){
+      trace->traceEvent(TRACE_ERROR, "Missing %s from %s", "unknown", path);
+        return(false);
+    }else{
+      marker_unknown.setValue(root["markers"]["unknown"].asUInt());
+    }
+    if(root["markers"]["pass"].empty()){
+      trace->traceEvent(TRACE_ERROR, "Missing %s from %s", "pass", path);
+        return(false);
+    }else{
+      marker_pass.setValue(root["markers"]["pass"].asUInt());
+    }
+    if(root["markers"]["drop"].empty()){
+      trace->traceEvent(TRACE_ERROR, "Missing %s from %s", "drop", path);
+        return(false);
+    }else{
+      marker_drop.setValue(root["markers"]["drop"].asUInt());
+    }
+  }
+
   if(root["default_policy"].empty()) {
     trace->traceEvent(TRACE_ERROR, "Missing %s from %s", "default_policy", path);
     return(false);
   } else {
     std::string m = root["default_policy"].asString();
     trace->traceEvent(TRACE_INFO, "Default policy: %s", m.c_str());
-    default_policy = (m == "PASS") ? MARKER_PASS : MARKER_DROP;
+    default_policy = (m == "PASS") ? marker_pass : marker_drop;
 
   }
 
@@ -100,7 +124,7 @@ bool Configuration::readConfigFile(const char *path) {
   if(all_tcp_ports) trace->traceEvent(TRACE_INFO, "All TCP ports will be monitored");
   if(all_udp_ports) trace->traceEvent(TRACE_INFO, "All UDP ports will be monitored");
 
-  std::string json_policy_str = default_policy == MARKER_DROP ? "drop" : "pass";
+  std::string json_policy_str = default_policy == marker_drop ? "drop" : "pass";
 
   if(!root["policy"].empty() && !root["policy"][json_policy_str].empty()) {
 
@@ -116,7 +140,7 @@ bool Configuration::readConfigFile(const char *path) {
             std::string ctry_cont = json_policy_obj[json_value_str+json_list_str][i].asString();
 
             trace->traceEvent(TRACE_INFO, "Adding %s to %s", ctry_cont.c_str(), (json_value_str+json_list_str).c_str());
-            ctrs_conts[ctry_cont2u16((char*)ctry_cont.c_str())] = json_policy_str == "drop" ? MARKER_PASS : MARKER_DROP;
+            ctrs_conts[ctry_cont2u16((char*)ctry_cont.c_str())] = json_policy_str == "drop" ? marker_pass : marker_drop;
           }
         }
       }while(--counter);

--- a/Configuration.h
+++ b/Configuration.h
@@ -40,7 +40,10 @@ class Configuration {
   u_int16_t ctry_cont2u16(char *country_code);
   
  public:
-  Configuration() { nfq_queue_id = 0, default_policy = MARKER_PASS; configured = false, all_tcp_ports = all_udp_ports = true; }
+  Configuration() { nfq_queue_id = 0, marker_unknown.setValue(0); 
+                    marker_pass.setValue(1); marker_drop.setValue(2);
+                    default_policy = marker_pass; configured = false, 
+                    all_tcp_ports = all_udp_ports = true; }
 
   bool readConfigFile(const char *path);
 

--- a/Configuration.h
+++ b/Configuration.h
@@ -28,9 +28,13 @@ class Configuration {
  private:
   std::unordered_map<u_int16_t, Marker> ctrs_conts;
   std::unordered_map<u_int16_t, bool>   tcp_ports, udp_ports, ignored_ports;
+  unsigned int nfq_queue_id;
+  Marker marker_unknown;
+  Marker marker_pass;
+  Marker marker_drop;
   Marker default_policy;
   Blacklists blacklists;
-  unsigned int nfq_queue_id;
+  
   bool configured, all_tcp_ports, all_udp_ports;
   
   u_int16_t ctry_cont2u16(char *country_code);
@@ -44,8 +48,11 @@ class Configuration {
   inline bool isConfigured()       { return(configured);   }
   
   inline void setQueueId(int nfq_id)                        { nfq_queue_id = nfq_id;  }
-  inline void setCountryMarker(u_int16_t country, Marker m) { ctrs_conts[country] = m; }
-  inline Marker getDefaultPolicy()                          { return(default_policy); }
+  inline void setCountryMarker(u_int16_t country, Marker m) { ctrs_conts[country] = m;}
+  inline Marker getMarkerUnknown(u_int16_t v)               { return marker_unknown;  }
+  inline Marker getMarkerPass(u_int16_t v)                  { return marker_pass;     }
+  inline Marker getMarkerDrop(u_int16_t v)                  { return marker_drop;     }
+  inline Marker getDefaultPolicy()                          { return default_policy;  }
   Marker getMarker(char *country, char *continent);
   inline bool isIgnoredPort(u_int16_t port)      { return(ignored_ports.find(port) != ignored_ports.end());            }
   inline bool isMonitoredTCPPort(u_int16_t port) { return(all_tcp_ports || (tcp_ports.find(port) != tcp_ports.end())); }

--- a/Configuration.h
+++ b/Configuration.h
@@ -52,9 +52,9 @@ class Configuration {
   
   inline void setQueueId(int nfq_id)                        { nfq_queue_id = nfq_id;  }
   inline void setCountryMarker(u_int16_t country, Marker m) { ctrs_conts[country] = m;}
-  inline Marker getMarkerUnknown(u_int16_t v)               { return marker_unknown;  }
-  inline Marker getMarkerPass(u_int16_t v)                  { return marker_pass;     }
-  inline Marker getMarkerDrop(u_int16_t v)                  { return marker_drop;     }
+  inline Marker getMarkerUnknown()                          { return marker_unknown;  }
+  inline Marker getMarkerPass()                             { return marker_pass;     }
+  inline Marker getMarkerDrop()                             { return marker_drop;     }
   inline Marker getDefaultPolicy()                          { return default_policy;  }
   Marker getMarker(char *country, char *continent);
   inline bool isIgnoredPort(u_int16_t port)      { return(ignored_ports.find(port) != ignored_ports.end());            }

--- a/NwInterface.cpp
+++ b/NwInterface.cpp
@@ -200,7 +200,7 @@ Marker NwInterface::dissectPacket(const u_char *payload, u_int payload_len) {
       struct in_addr a;
 
       if ((iph->protocol == IPPROTO_UDP) && ((frag_off & 0x3FFF /* IP_MF | IP_OFFSET */) != 0))
-        return (conf->getMarkerUnknown); /* Don't block it */
+        return (conf->getMarkerUnknown()); /* Don't block it */
 
       // get protocol and offset
       proto = iph->protocol;
@@ -209,7 +209,7 @@ Marker NwInterface::dissectPacket(const u_char *payload, u_int payload_len) {
       a.s_addr = iph->saddr, inet_ntop(AF_INET, &a, src, sizeof(src));
       a.s_addr = iph->daddr, inet_ntop(AF_INET, &a, dst, sizeof(dst));
     } else { // Neither ipv4 or ipv6...unlikely to be evaluated
-      return (conf->getMarkerPass);
+      return (conf->getMarkerPass());
     }
 
     u_int8_t *nxt = ((u_int8_t *)iph + ip_payload_offset);
@@ -233,7 +233,7 @@ Marker NwInterface::dissectPacket(const u_char *payload, u_int payload_len) {
                         src,dst, ipv4,ipv6));
   }
   
-  return (conf->getMarkerPass);
+  return (conf->getMarkerPass());
 }
 
 /* **************************************************** */
@@ -350,7 +350,7 @@ Marker NwInterface::makeVerdict(u_int8_t proto, u_int16_t vlanId,
 	      dst_host, dport, dst_ctry, dst_cont, false,
 	      false /* drop */);
 
-      return(conf->getMarkerDrop);
+      return(conf->getMarkerDrop());
     }
 
     in.s_addr = daddr;
@@ -360,7 +360,7 @@ Marker NwInterface::makeVerdict(u_int8_t proto, u_int16_t vlanId,
 	      dst_host, dport, dst_ctry, dst_cont, true,
 	      false /* drop */);
 
-      return(conf->getMarkerDrop);
+      return(conf->getMarkerDrop());
     }
   }
   if (ipv6) {
@@ -372,7 +372,7 @@ Marker NwInterface::makeVerdict(u_int8_t proto, u_int16_t vlanId,
               dst_host, dport, dst_ctry, dst_cont, false,
               false /* drop */);
 
-      return (conf->getMarkerDrop);
+      return (conf->getMarkerDrop());
     }
 
     inet_pton(AF_INET6, dst_host, &a);
@@ -382,7 +382,7 @@ Marker NwInterface::makeVerdict(u_int8_t proto, u_int16_t vlanId,
               dst_host, dport, dst_ctry, dst_cont, true,
               false /* drop */);
 
-      return (conf->getMarkerDrop);
+      return (conf->getMarkerDrop());
     }
   }
 
@@ -393,7 +393,7 @@ Marker NwInterface::makeVerdict(u_int8_t proto, u_int16_t vlanId,
       ;
     else {
       trace->traceEvent(TRACE_INFO, "Ignoring TCP ports %u/%u", sport, dport);
-      return(conf->getMarkerPass);
+      return(conf->getMarkerPass());
     }
     break;
 
@@ -402,7 +402,7 @@ Marker NwInterface::makeVerdict(u_int8_t proto, u_int16_t vlanId,
       ;
     else {
       trace->traceEvent(TRACE_INFO, "Ignoring UDP ports %u/%u", sport, dport);
-      return(conf->getMarkerPass);
+      return(conf->getMarkerPass());
     }
     break;
   }
@@ -415,7 +415,7 @@ Marker NwInterface::makeVerdict(u_int8_t proto, u_int16_t vlanId,
     pass_local = false;
   } else {
     /* Unknown or private IP address  */
-    src_marker = conf->getMarkerPas;
+    src_marker = conf->getMarkerPass();
   }
 
   if((!daddr_private) && (geoip->lookup(dst_host, dst_ctry, sizeof(dst_ctry), dst_cont, sizeof(dst_cont)))) {
@@ -423,21 +423,21 @@ Marker NwInterface::makeVerdict(u_int8_t proto, u_int16_t vlanId,
     pass_local = false;
   } else {
     /* Unknown or private IP address  */
-    dst_marker = conf->getMarkerPas;
+    dst_marker = conf->getMarkerPass();
   }
 
   /* Final step: compute the flow verdict */
 
   if((conf->isIgnoredPort(sport) || conf->isIgnoredPort(dport))
-     || ((src_marker == conf->getMarkerPass) && (dst_marker == conf->getMarkerPass))) {
-    m = conf->getMarkerPas;
+     || ((src_marker == conf->getMarkerPass()) && (dst_marker == conf->getMarkerPass()))) {
+    m = conf->getMarkerPass();
 
     logFlow(proto_name,
 	    src_host, sport, src_ctry, src_cont, false,
 	    dst_host, dport, dst_ctry, dst_cont, false,
 	    true /* pass */);
   } else {
-    m = conf->getMarkerDrop;
+    m = conf->getMarkerDrop();
 
     logFlow(proto_name,
 	    src_host, sport, src_ctry, src_cont, false,

--- a/NwInterface.cpp
+++ b/NwInterface.cpp
@@ -200,7 +200,7 @@ Marker NwInterface::dissectPacket(const u_char *payload, u_int payload_len) {
       struct in_addr a;
 
       if ((iph->protocol == IPPROTO_UDP) && ((frag_off & 0x3FFF /* IP_MF | IP_OFFSET */) != 0))
-        return (MARKER_UNKNOWN); /* Don't block it */
+        return (conf->getMarkerUnknown); /* Don't block it */
 
       // get protocol and offset
       proto = iph->protocol;
@@ -209,7 +209,7 @@ Marker NwInterface::dissectPacket(const u_char *payload, u_int payload_len) {
       a.s_addr = iph->saddr, inet_ntop(AF_INET, &a, src, sizeof(src));
       a.s_addr = iph->daddr, inet_ntop(AF_INET, &a, dst, sizeof(dst));
     } else { // Neither ipv4 or ipv6...unlikely to be evaluated
-      return (MARKER_PASS);
+      return (conf->getMarkerPass);
     }
 
     u_int8_t *nxt = ((u_int8_t *)iph + ip_payload_offset);
@@ -233,7 +233,7 @@ Marker NwInterface::dissectPacket(const u_char *payload, u_int payload_len) {
                         src,dst, ipv4,ipv6));
   }
   
-  return (MARKER_PASS);
+  return (conf->getMarkerPass);
 }
 
 /* **************************************************** */
@@ -350,7 +350,7 @@ Marker NwInterface::makeVerdict(u_int8_t proto, u_int16_t vlanId,
 	      dst_host, dport, dst_ctry, dst_cont, false,
 	      false /* drop */);
 
-      return(MARKER_DROP);
+      return(conf->getMarkerDrop);
     }
 
     in.s_addr = daddr;
@@ -360,7 +360,7 @@ Marker NwInterface::makeVerdict(u_int8_t proto, u_int16_t vlanId,
 	      dst_host, dport, dst_ctry, dst_cont, true,
 	      false /* drop */);
 
-      return(MARKER_DROP);
+      return(conf->getMarkerDrop);
     }
   }
   if (ipv6) {
@@ -372,7 +372,7 @@ Marker NwInterface::makeVerdict(u_int8_t proto, u_int16_t vlanId,
               dst_host, dport, dst_ctry, dst_cont, false,
               false /* drop */);
 
-      return (MARKER_DROP);
+      return (conf->getMarkerDrop);
     }
 
     inet_pton(AF_INET6, dst_host, &a);
@@ -382,7 +382,7 @@ Marker NwInterface::makeVerdict(u_int8_t proto, u_int16_t vlanId,
               dst_host, dport, dst_ctry, dst_cont, true,
               false /* drop */);
 
-      return (MARKER_DROP);
+      return (conf->getMarkerDrop);
     }
   }
 
@@ -393,7 +393,7 @@ Marker NwInterface::makeVerdict(u_int8_t proto, u_int16_t vlanId,
       ;
     else {
       trace->traceEvent(TRACE_INFO, "Ignoring TCP ports %u/%u", sport, dport);
-      return(MARKER_PASS);
+      return(conf->getMarkerPass);
     }
     break;
 
@@ -402,7 +402,7 @@ Marker NwInterface::makeVerdict(u_int8_t proto, u_int16_t vlanId,
       ;
     else {
       trace->traceEvent(TRACE_INFO, "Ignoring UDP ports %u/%u", sport, dport);
-      return(MARKER_PASS);
+      return(conf->getMarkerPass);
     }
     break;
   }
@@ -415,7 +415,7 @@ Marker NwInterface::makeVerdict(u_int8_t proto, u_int16_t vlanId,
     pass_local = false;
   } else {
     /* Unknown or private IP address  */
-    src_marker = MARKER_PASS;
+    src_marker = conf->getMarkerPas;
   }
 
   if((!daddr_private) && (geoip->lookup(dst_host, dst_ctry, sizeof(dst_ctry), dst_cont, sizeof(dst_cont)))) {
@@ -423,21 +423,21 @@ Marker NwInterface::makeVerdict(u_int8_t proto, u_int16_t vlanId,
     pass_local = false;
   } else {
     /* Unknown or private IP address  */
-    dst_marker = MARKER_PASS;
+    dst_marker = conf->getMarkerPas;
   }
 
   /* Final step: compute the flow verdict */
 
   if((conf->isIgnoredPort(sport) || conf->isIgnoredPort(dport))
-     || ((src_marker == MARKER_PASS) && (dst_marker == MARKER_PASS))) {
-    m = MARKER_PASS;
+     || ((src_marker == conf->getMarkerPass) && (dst_marker == conf->getMarkerPass))) {
+    m = conf->getMarkerPas;
 
     logFlow(proto_name,
 	    src_host, sport, src_ctry, src_cont, false,
 	    dst_host, dport, dst_ctry, dst_cont, false,
 	    true /* pass */);
   } else {
-    m = MARKER_DROP;
+    m = conf->getMarkerDrop;
 
     logFlow(proto_name,
 	    src_host, sport, src_ctry, src_cont, false,

--- a/include.h
+++ b/include.h
@@ -65,17 +65,18 @@
 
 /* ********************************************** */
 
-typedef enum {
-  MARKER_UNKNOWN = 0,
-  MARKER_PASS    = 1,
-  MARKER_DROP    = 2
-} Marker;
+class Marker{
+ private:
+  u_int16_t value;
 
+ public:
+  inline void setValue(u_int16_t v){value=v;}
+  operator u_int16_t() {return value;}
+};
 
 //#if !defined(__mips__)
 #define HAVE_NFQ_SET_VERDICT2 1
 //#endif
-
 
 #define NF_BUFFER_SIZE     (32768*16384)
 #define NF_MAX_QUEUE_LEN   (8192)

--- a/sample_config.json
+++ b/sample_config.json
@@ -1,5 +1,10 @@
 {
 	"queue_id": 0,
+	"markers": {
+		"unknown": 0,
+		"pass": 1,
+		"drop": 2
+	},
 	"default_policy": "DROP",
 	"monitored_ports": {
 		"tcp": [22, 80, 443],


### PR DESCRIPTION
Solves issue #18.
Aiming to keep previous class contracts unchanged, i have replaced Marker enum with a wrapper class of u_int16_t . 
Now a Configuration object stores 3 Marker objects (unknown, pass, drop) that are loaded at runtime from the configuration file, and can be accessed with their respective get methods.
All the other changes are a natural consequence of the first two.