### PR TITLE
Added functionality to calculate banning time for each host.

### DIFF
--- a/Configuration.cpp
+++ b/Configuration.cpp
@@ -52,6 +52,7 @@ Configuration::~Configuration() {
   telegramThread->join();
   cmdThread->join();
   delete telegramThread;
+  delete cmdThread;
 }
 
 /* *************************2****************************** */
@@ -268,6 +269,16 @@ bool Configuration::readConfigFile(const char *path) {
 
       blacklists.loadIPsetFromURL(url.c_str());
     }
+  }
+
+  /* **************************** */
+
+  if(root["blacklist_dump_path"].empty()) {
+    trace->traceEvent(TRACE_ERROR, "Missing %s from %s", "blacklist_dump_path", path);
+    return(false);
+  } else {
+    const char *dump_path = root["blacklist_dump_path"].asCString();
+    blacklists.setDumpPath(dump_path);
   }
 
   /* **************************** */

--- a/Configuration.h
+++ b/Configuration.h
@@ -85,6 +85,10 @@ class Configuration {
   inline bool isMonitoredUDPPort(u_int16_t port) { return(all_udp_ports || (udp_ports.find(port) != udp_ports.end())); }
   bool isProtectedPort(u_int16_t port);
 
+  inline void save()                                                                     { blacklists.save(); }
+  inline void load(std::unordered_map<std::string, WatchMatches*>& watches_blacklist)  { blacklists.load(watches_blacklist); }
+  inline void cleanAddresses()                                                                    { blacklists.cleanAddresses(); }
+
   inline bool isBlacklistedIPv4(struct in_addr *addr)               { return(blacklists.isListedIPv4(addr));  }
   inline bool isBlacklistedIPv6(struct in6_addr *addr6)             { return(blacklists.isListedIPv6(addr6)); }
 

--- a/Lists.cpp
+++ b/Lists.cpp
@@ -65,7 +65,7 @@ void Lists::addAddress(int family, void *addr, int bits) {
 /* ****************************************** */
 
 bool Lists::isListedIPv4(struct in_addr *addr) {
-  if(findIp(addr, true)) return true;
+  if(findIp(addr, true /* is_ipv4 */)) return true;
   ndpi_prefix_t prefix;
 
   ndpi_fill_prefix_v4(&prefix, addr, 32, ptree_v4->maxbits);
@@ -79,7 +79,7 @@ bool Lists::isListedIPv4(struct in_addr *addr) {
 /* ****************************************** */
 
 bool Lists::isListedIPv6(struct in6_addr *addr6) {
-  if(findIp(addr6, false)) return true;
+  if(findIp(addr6, false /* is_ipv4 */)) return true;
   ndpi_prefix_t prefix;
 
   ndpi_fill_prefix_v6(&prefix, addr6, 128, ptree_v6->maxbits);

--- a/Lists.h
+++ b/Lists.h
@@ -22,6 +22,11 @@
 #ifndef _LISTS_H_
 #define _LISTS_H_
 
+/* With this number of entries the memory used by the unordered_map will be about 1gb.
+ * If you want to increase the limit, remember that it tends to 10940000 * x --> 1gb * x
+ */
+#define MAX_ENTRIES 10940000
+
 #include <unordered_map>
 #include "WatchMatches.h"
 /* ******************************* */

--- a/Lists.h
+++ b/Lists.h
@@ -22,24 +22,32 @@
 #ifndef _LISTS_H_
 #define _LISTS_H_
 
+#include <unordered_map>
+#include "WatchMatches.h"
 /* ******************************* */
 
 class Lists {
  private:
+  std::string dump_path;
   ndpi_patricia_tree_t *ptree_v4, *ptree_v6;
-  
   void addAddress(int family, void *addr, int bits);
   bool findAddress(int family, struct in_addr *addr, int bits);
+  bool findIp(void *addr, bool is_ipv4);
 
  public:
   Lists();
   ~Lists();
-
+  std::unordered_map<std::string, WatchMatches*> watches_blacklist;
   bool findAddress(char *addr);
   void addAddress(char *net);
   void removeAddress(char *net);
   bool loadIPsetFromFile(const char *path);
   bool loadIPsetFromURL(const char *url);
+
+  bool load(std::unordered_map<std::string, WatchMatches*>& watches);
+  bool save();
+  void cleanAddresses();
+  void setDumpPath(const char *path) { dump_path = std::string(path); }
 
   bool isListedIPv4(struct in_addr *pin);
   bool isListedIPv6(struct in6_addr *addr6);

--- a/NwInterface.cpp
+++ b/NwInterface.cpp
@@ -174,7 +174,7 @@ void NwInterface::packetPollLoop() {
   int fd;
   std::vector<bool>  geo_ip_pipes;
   u_int num_loops = 0;
-  conf ->load(watches_blacklist);
+  conf->load(watches_blacklist);
   watches = conf->get_watches();
 
   /* Spawn reload config thread in background */
@@ -347,7 +347,7 @@ void NwInterface::packetPollLoop() {
 
     if((id == 0) || (num_loops > NUM_PURGE_LOOP)) {
       harvestWatches();
-      conf -> cleanAddresses();
+      conf->cleanAddresses();
       num_loops = 0;
     }
 
@@ -361,7 +361,7 @@ void NwInterface::packetPollLoop() {
       trace->traceEvent(TRACE_NORMAL, "New configuration has been updated");
     }
   } /* while */
-  conf ->save();
+  conf->save();
   trace->traceEvent(TRACE_NORMAL, "Leaving packet poll loop");
 
   ifaceRunning = false;
@@ -837,7 +837,7 @@ void NwInterface::reloadConfLoop() {
 /* **************************************************** */
 
 void NwInterface::harvestWatches() {
-
+  u_int32_t currentTime = time(NULL);
 #ifdef DEBUG
   trace->traceEvent(TRACE_NORMAL, "NwInterface::harvestWatches()");
 #endif
@@ -849,11 +849,14 @@ void NwInterface::harvestWatches() {
     trace->traceEvent(TRACE_NORMAL, "last_match=%u / now=%u [to go: %d]",
 		      match->get_last_match(), when, (match->get_last_match() - when));
 #endif
-    if(match->ready_to_harvest()) {
+    if(match->ready_to_harvest(currentTime)) {
 #ifdef DEBUG
       trace->traceEvent(TRACE_NORMAL, "Harvesting");
 #endif
       ban((char*)it->first.c_str(), false /* unban */, false, "unban", "");
+      /* Entries will be deleted after 24hr since the unban if they don't get banned again.
+       * The method cleanAddresses takes care of this task.
+       */
       it->second->isBanned = false;
     } else
       ++it;
@@ -870,14 +873,15 @@ void NwInterface::ban(char *host, bool ban_ip,
 
   if(ban_ip) {
     /* Ban */
-
-    if(it == watches_blacklist.end()) {
+    // Note: watches_blacklist inserts entries until MAX_ENTRIES is reached.
+    // After that, it will start inserting again only if space has been freed by the cleanAddresses method.
+    if(it == watches_blacklist.end() && watches_blacklist.size() < MAX_ENTRIES) {
       WatchMatches *match = new WatchMatches();
       watches_blacklist[host] = match;
       if(fw) fw->ban(host, is_ipv4);
       match->isBanned = true;
       logHostBan(host, ban_ip, ban_traffic, reason, country);
-    } else {
+    } else if (it != watches_blacklist.end()){
       WatchMatches *m = it->second;
       m->inc_matches();
       m->isBanned = true;

--- a/WatchMatches.h
+++ b/WatchMatches.h
@@ -25,20 +25,31 @@
 
 class WatchMatches {
 private:
-  u_int32_t last_match, num_matches;
+  u_int32_t last_match;
+  u_int64_t num_matches;
   int max_matches = 22;
 public:
   WatchMatches() { last_match = time(NULL), num_matches = 1; }
+  /* This constructor is used when we load the entries from file. */
   WatchMatches(u_int32_t _num_matches, u_int32_t _last_matches) { last_match = _last_matches, num_matches = _num_matches; }
+  /*
+   * Default function: max_matches = 22,
+   * f(22) = 177148 * 100 ('* 100' it's required to convert in seconds) = ban for 205 days.
+   * We put 22 as max value because after 23 matches the ban is greater than 1 year.
+   * By changing max_matches you can change the max banning time.
+   * f(1) = 3 * 100 = ban for five minutes.
+   * You can change these parameters accordingly to your needs.
+   * */
   int f(float x) {
       if (x >= max_matches) return 315360; //ban for one year at this point
-      return (int) (std::pow(3, x * 1 /* Change this value if you want to make the function more or less steep */));
+      // /* Change this values if you want to make the function more or less steep */
+      return (int) (std::pow(3, x * 0.5)) + 1.5;
   }
   bool isBanned = false;
   inline u_int32_t get_last_match()   { return(last_match);                     }
-  inline u_int32_t get_num_matches()  { return(num_matches);                    }
+  inline u_int64_t get_num_matches()  { return(num_matches);                    }
   inline void      inc_matches()      { num_matches++, last_match = time(NULL); }
-  inline bool      ready_to_harvest() { return((last_match < time(NULL) - f(get_num_matches()) * 100 ) ? true : false); }
+  inline bool      ready_to_harvest(u_int32_t currentTime) { return((last_match < currentTime - f(get_num_matches()) * 100 ) ? true : false); }
 };
 
 #endif /* _WATCH_MATCHES_H_ */

--- a/WatchMatches.h
+++ b/WatchMatches.h
@@ -21,19 +21,24 @@
 #ifndef _WATCH_MATCHES_H_
 #define _WATCH_MATCHES_H_
 
-#define MAX_IDLENESS   300 /* 5 minutes */
+
 
 class WatchMatches {
 private:
   u_int32_t last_match, num_matches;
-
+  int max_matches = 22;
 public:
   WatchMatches() { last_match = time(NULL), num_matches = 1; }
-
+  WatchMatches(u_int32_t _num_matches, u_int32_t _last_matches) { last_match = _last_matches, num_matches = _num_matches; }
+  int f(float x) {
+      if (x >= max_matches) return 315360; //ban for one year at this point
+      return (int) (std::pow(3, x * 1 /* Change this value if you want to make the function more or less steep */));
+  }
+  bool isBanned = false;
   inline u_int32_t get_last_match()   { return(last_match);                     }
   inline u_int32_t get_num_matches()  { return(num_matches);                    }
   inline void      inc_matches()      { num_matches++, last_match = time(NULL); }
-  inline bool      ready_to_harvest(u_int32_t when) { return((last_match < when) ? true : false); }
+  inline bool      ready_to_harvest() { return((last_match < time(NULL) - f(get_num_matches()) * 100 ) ? true : false); }
 };
 
 #endif /* _WATCH_MATCHES_H_ */

--- a/configure.ac
+++ b/configure.ac
@@ -117,7 +117,7 @@ else
   INCS="$INCS -I $HOME/nDPI/src/include"
 fi
 
-LIBS="$LIBS -lpthread"
+LIBS="$LIBS -lpthread -lm"
 
 EXTN=
 if test $MACHINE = "x86_64"; then

--- a/include.h
+++ b/include.h
@@ -94,6 +94,7 @@ extern "C" {
 #include <vector>
 #include <mutex>
 #include <queue>
+#include <cmath>
 
 /* ********************************************** */
 

--- a/ipt_config_utils/single_iface.sh
+++ b/ipt_config_utils/single_iface.sh
@@ -39,6 +39,7 @@ for i in {1,2}; do
     # Flush all if already there
     $IPTABLES -F IPT_GEOFENCE_BLACKLIST
     $IPTABLES -X IPT_GEOFENCE_BLACKLIST
+    $IPTABLES -N IPT_GEOFENCE_BLACKLIST
     # Return to the original chain
     $IPTABLES -A IPT_GEOFENCE_BLACKLIST -j RETURN
     # Jump to the blacklist chain

--- a/main.cpp
+++ b/main.cpp
@@ -215,6 +215,7 @@ int main(int argc, char *argv[]) {
   
   delete iface;
   delete conf;
+  delete trace;
 
   return(0);
 }

--- a/sample_config.json
+++ b/sample_config.json
@@ -21,6 +21,7 @@
 	    "continents_blacklist": []
 	}
     },
+	"blacklist_dump_path" : "/var/tmp/banned_addresses.txt",
     "blacklists": [
 	"https://raw.githubusercontent.com/firehol/blocklist-ipsets/master/dshield_7d.netset",
 	"https://raw.githubusercontent.com/firehol/blocklist-ipsets/master/alienvault_reputation.ipset",


### PR DESCRIPTION
Changes from the previous pull request:
- The dump path is now read from the config file and is no longer hardcoded.
- Simplified WatchMatches.
- Simplified the load and save functions and added error handling.
- Renamed method names.
- Changed the "define" name  to DISCARD from DROP.
- Modified the load method to skip expired entries during loading.
- Removed "findIpv4" and "findIpv6" methods in favor of "findIp", which now uses a boolean to determine whether to search for an IPv4 or an IPv6 address.